### PR TITLE
use $HOME for install step, as `~/` isn't being properly expanded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help llvm llvm-with-docs dist docker enable-docs disable-docs
 
 IMAGE_NAME ?= llvm
-XDG_DATA_HOME ?= ~/.local/share
+XDG_DATA_HOME ?= $(HOME)/.local/share
 BUILD_DOCS ?= OFF
 RELEASE ?= 10.0.0
 CWD = `pwd`


### PR DESCRIPTION
I run into the problem that after compiling the message said:
`# Installing the release to ~/.local/share/llvm/lumen`

.. however that folder was never there. Turns out it was copied to a folder relative to the build as `~` wasn't being expanded to `$HOME`, dumping it in:
`build/host/stage2/RelWithDebInfo/~/.local/share/llvm/lumen/`

Hope this fixes it, didn't have the time yet to try it out